### PR TITLE
Fix missing data directory

### DIFF
--- a/data
+++ b/data
@@ -1,0 +1,1 @@
+build/data/


### PR DESCRIPTION
Could we add a symlink here so ./rockbot works in QtCreator? That's what I'm using as a compiler until I get used to using qmake from the console. Also something tells me I should be using the built-in debugger in the near future for my next bug.
