### PR TITLE
Fix/weapon change crashes game

### DIFF
--- a/class_config.cpp
+++ b/class_config.cpp
@@ -434,7 +434,7 @@ st_position class_config::convert_stage_n_to_menu_pos(short stage_n) const
 }
 
 
-Uint8 class_config::find_next_weapon(Uint8 current, Uint8 move) const
+Sint8 class_config::find_next_weapon(Uint8 current, Uint8 move) const
 {
     if (move == 1) {
         for (int i=current+1; i<WEAPON_COUNT; i++) { // from position to end

--- a/class_config.h
+++ b/class_config.h
@@ -55,7 +55,7 @@ public:
     st_position convert_stage_n_to_menu_pos(short stage_n) const;
 
 
-    Uint8 find_next_weapon(Uint8 current, Uint8 move) const; // used by L/R buttons
+    Sint8 find_next_weapon(Uint8 current, Uint8 move) const; // used by L/R buttons
 
     void disable_ingame_menu();
 


### PR DESCRIPTION
Opening screen, you're ready to play, and you hit the weapon change button by accident. It crashes the game! This should fix that.
