### PR TITLE
st_position_uint8 should have two Uint8's

### DIFF
--- a/file/format/st_common.h
+++ b/file/format/st_common.h
@@ -340,8 +340,8 @@ struct st_position_int8 {
 
 
 struct st_position_uint8 {
-    Sint8 x;
-    Sint8 y;
+    Uint8 x;
+    Uint8 y;
     st_position_uint8() {
         x = 0;
         y = 0;


### PR DESCRIPTION
The stage data gets corrupted when we try to address any tile with `pos.x > 128` . This should be a fix for that.
